### PR TITLE
Fix entity-context overlap issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - remove a default spacy abbreviation (`ts.`)
 
+### Fixed
+
+- issue where entity and context trigger were overlapping (e.g. `geen eetlust`)
+
 ## 0.2.0 (2023-06-07)
 
 ### Added

--- a/clinlp/component/qualifier.py
+++ b/clinlp/component/qualifier.py
@@ -326,7 +326,7 @@ class ContextMatcher:
                 qualifiers = set()
 
                 for match_interval in match_scopes.overlap(ent.start, ent.end):
-                    if ent.start + 1 > match_interval.data.end or ent.end < match_interval.data.start + 1:
+                    if (ent.start + 1 > match_interval.data.end) or (ent.end < match_interval.data.start + 1):
                         qualifiers.add(str(match_interval.data.rule.qualifier))
 
                 ent._.set(QUALIFIERS_ATTR, qualifiers)

--- a/clinlp/component/qualifier.py
+++ b/clinlp/component/qualifier.py
@@ -326,7 +326,8 @@ class ContextMatcher:
                 qualifiers = set()
 
                 for match_interval in match_scopes.overlap(ent.start, ent.end):
-                    qualifiers.add(str(match_interval.data.rule.qualifier))
+                    if ent.start + 1 > match_interval.data.end or ent.end < match_interval.data.start + 1:
+                        qualifiers.add(str(match_interval.data.rule.qualifier))
 
                 ent._.set(QUALIFIERS_ATTR, qualifiers)
 

--- a/clinlp/language.py
+++ b/clinlp/language.py
@@ -85,7 +85,7 @@ CLINLP_ABBREVIATIONS = [
 ]
 
 CLINLP_REMOVE_ABBREVIATIONS = [
-    'ts.',
+    "ts.",
 ]
 
 CLINLP_UNITS = [
@@ -237,7 +237,6 @@ ALPHA = "a-zA-Z"
 
 
 def _get_abbreviations():
-
     base = set(spacy.lang.nl.tokenizer_exceptions.abbrevs.copy())
 
     for abbrev in CLINLP_REMOVE_ABBREVIATIONS:

--- a/tests/unit/test_qualifier_matcher.py
+++ b/tests/unit/test_qualifier_matcher.py
@@ -254,6 +254,30 @@ class TestUnitQualifierMatcher:
 
         assert "Negation.NEGATED" in doc.ents[0]._.qualifiers
 
+    def test_overlap_rule_and_ent(self):
+        nlp = spacy.blank("clinlp")
+        nlp.add_pipe("clinlp_sentencizer")
+        ruler = nlp.add_pipe("entity_ruler")
+        ruler.add_patterns([{"label": "symptoom", "pattern": "geen eetlust"}])
+
+        rules = parse_rules(
+            data={
+                "qualifiers": [
+                    {"qualifier": "Negation", "levels": ["AFFIRMED", "NEGATED"]},
+                ],
+                "rules": [
+                    {"patterns": ["geen"], "qualifier": "Negation.NEGATED", "direction": "preceding"},
+                ],
+            }
+        )
+
+        text = "Patient laat weten geen eetlust te hebben"
+
+        qm = ContextMatcher(nlp=nlp, name="_", default_rules=None, rules=rules)
+        doc = qm(nlp(text))
+
+        assert "Negation.NEGATED" not in doc.ents[0]._.qualifiers
+
     def test_load_default_rules(self, nlp):
         qm = ContextMatcher(nlp=nlp, name="_")
 


### PR DESCRIPTION
* Fixed an issue where a context trigger and an entity are overlapping (e.g. `geen eetlust`)