### PR TITLE
Fix bug with termination trigger next to positive trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## (unreleased)
+
+### Fixed
+* Fix a bug with termination trigger directly next to context trigger
+
 ## 0.6.2 (2023-10-06)
 
 ### Fixed

--- a/clinlp/qualifier/context_algorithm.py
+++ b/clinlp/qualifier/context_algorithm.py
@@ -278,13 +278,13 @@ class ContextAlgorithm(QualifierDetector):
 
                 if (
                     match.rule.direction == ContextRuleDirection.PRECEDING
-                    and terminate_match.start > match.end
+                    and terminate_match.start >= match.end
                 ):
                     match.scope = (match.scope[0], terminate_match.start)
 
                 if (
                     match.rule.direction == ContextRuleDirection.FOLLOWING
-                    and terminate_match.end < match.start
+                    and terminate_match.end <= match.start
                 ):
                     match.scope = (terminate_match.end, match.scope[1])
 

--- a/tests/unit/qualifier/test_context_algorithm.py
+++ b/tests/unit/qualifier/test_context_algorithm.py
@@ -449,6 +449,36 @@ class TestUnitContextAlgorithm:
         assert "Negation.Negated" in getattr(doc.ents[0]._, ATTR_QUALIFIERS_STR)
         assert "Negation.Negated" not in getattr(doc.ents[1]._, ATTR_QUALIFIERS_STR)
 
+    def test_match_qualifiers_termination_directly_preceding(self, nlp):
+        rules = {
+            "qualifiers": [
+                {"name": "Plausibility", "values": ["Plausible", "Hypothetical"]},
+            ],
+            "rules": [
+                {
+                    "patterns": ["mogelijk"],
+                    "qualifier": "Plausibility.Hypothetical",
+                    "direction": "following",
+                },
+                {
+                    "patterns": [","],
+                    "qualifier": "Plausibility.Hypothetical",
+                    "direction": "termination",
+                },
+            ],
+        }
+
+        text = "SYMPTOOM, mogelijk SYMPTOOM"
+        ca = ContextAlgorithm(nlp=nlp, rules=rules)
+        doc = ca(nlp(text))
+
+        assert "Plausibility.Hypothetical" not in getattr(
+            doc.ents[0]._, ATTR_QUALIFIERS_STR
+        )
+        assert "Plausibility.Hypothetical" not in getattr(
+            doc.ents[1]._, ATTR_QUALIFIERS_STR
+        )
+
     def test_match_qualifiers_termination_following(self, nlp):
         rules = {
             "qualifiers": [
@@ -474,6 +504,36 @@ class TestUnitContextAlgorithm:
 
         assert "Negation.Negated" not in getattr(doc.ents[0]._, ATTR_QUALIFIERS_STR)
         assert "Negation.Negated" in getattr(doc.ents[1]._, ATTR_QUALIFIERS_STR)
+
+    def test_match_qualifiers_termination_directly_following(self, nlp):
+        rules = {
+            "qualifiers": [
+                {"name": "Plausibility", "values": ["Plausible", "Hypothetical"]},
+            ],
+            "rules": [
+                {
+                    "patterns": ["mogelijk"],
+                    "qualifier": "Plausibility.Hypothetical",
+                    "direction": "preceding",
+                },
+                {
+                    "patterns": ["op basis van"],
+                    "qualifier": "Plausibility.Hypothetical",
+                    "direction": "termination",
+                },
+            ],
+        }
+
+        text = "SYMPTOOM mogelijk op basis van SYMPTOOM"
+        ca = ContextAlgorithm(nlp=nlp, rules=rules)
+        doc = ca(nlp(text))
+
+        assert "Plausibility.Hypothetical" not in getattr(
+            doc.ents[0]._, ATTR_QUALIFIERS_STR
+        )
+        assert "Plausibility.Hypothetical" not in getattr(
+            doc.ents[1]._, ATTR_QUALIFIERS_STR
+        )
 
     def test_match_qualifiers_multiple_sentences(self, nlp):
         rules = {


### PR DESCRIPTION
* Fix a bug with termination trigger directly next to context trigger, e.g. `SYMPTOOM mogelijk, SYMPTOOM` (trigger `mogelijk` directly followed by pseudo trigger `,`)